### PR TITLE
Fix expected output for auditing 4.1.1.2

### DIFF
--- a/section_4/cis_4.1.1/cis_4.1.1.2.yml
+++ b/section_4/cis_4.1.1/cis_4.1.1.2.yml
@@ -20,7 +20,7 @@ command:
     exec: grubby --info=ALL | grep -Po 'audit=1'
     exit-status: 0
     stdout:
-    - '/^saudit=1/'
+    - '/^audit=1/'
     meta:
       server: 2
       workstation: 2


### PR DESCRIPTION
Goss is expecting the output to be "saudit=1" when it is in fact "audit=1".