### PR TITLE
Updating regex for clientalivecountmax to match requirement standard

### DIFF
--- a/section_5/cis_5.2/cis_5.2.20.yml
+++ b/section_5/cis_5.2/cis_5.2.20.yml
@@ -6,7 +6,7 @@ file:
     exists: true
     contents:
     - '/^ClientAliveInterval ([1-9]|[1-9][0-9]|[1-8][0-9][0-9]|900)/'
-    - '/^ClientAliveCountMax 0/'
+    - '/^ClientAliveCountMax\s+([1-9][0-9]*)$/'
     meta:
       server: 1
       workstation: 1
@@ -26,7 +26,7 @@ command:
       - 1
     stdout:
     - '/^clientaliveinterval ([1-9]|[1-9][0-9]|[1-8][0-9][0-9]|900)/'
-    - '/^clientalivecountmax 0/'
+    - '/^clientalivecountmax\s+([1-9][0-9]*)$/'
     meta:
       server: 1
       workstation: 1


### PR DESCRIPTION
**Overall Review of Changes:**
- Updated 5.2.20 to check that /etc/ssh/sshd_config contains ClientAliveCountMax value > 0
- Updated 5.2.20 to check that stdout of _sshd -T | grep clientalive_ contains clientalivecountmax > 0

**Issue Fixes:**
This fixes the interpretation of the v1 5.2.20 rule.  The CIS standard states:

> ClientAliveCountMax must be greater than zero in order to utilize the ability of SSH to drop idle connections. If connections are allowed to stay open indefinitely, this can potentially be used as a DDOS attack or simple resource exhaustion could occur over unreliable networks.

**How has this been tested?:**
Tested on deployment of RHEL9 AMI running in AWS.  I have not tested negative/postive results.  Please let me know if you need more testing.
