### PR TITLE
Incorrect awk field selection in cis_7.1.1[123].yml

### DIFF
--- a/section_1/cis_1.2.x/cis_1.2.1.2.yml
+++ b/section_1/cis_1.2.x/cis_1.2.1.2.yml
@@ -21,7 +21,7 @@ command:
       CISv8_IG3: true
       NIST800-53R5: SI-2
   gpg_check_repo:
-    title: 1.2.2 | Ensure gpgcheck is globally active
+    title: 1.2.1.2 | Ensure gpgcheck is globally active
     exit-status: 0
     exec: "if [ `grep -c -E '^\\s*gpgcheck.*0' /etc/yum.repos.d/*.repo` -ge 1 ]; then echo FAIL; elif [ `grep -c -E '^\\s*gpgcheck.*1' /etc/yum.repos.d/*.repo` -ge 1 ]; then echo Passed_Check;fi"
     timeout: {{ .Vars.timeout_ms }}
@@ -29,7 +29,7 @@ command:
       server: 1
       workstation: 1
       CIS_ID:
-      - 1.2.2
+      - 1.2.1.2
       CISv8:
       - 7.3
       CISv8_IG1: true

--- a/section_7/cis_7.1/cis_7.1.11.yml
+++ b/section_7/cis_7.1/cis_7.1.11.yml
@@ -6,7 +6,7 @@
 command:
   sticky_bit:
     title: 7.1.11 | Ensure world writable files and directories are secured
-    exec: "df --local -P | awk '{if (NR!=1) print $7}' | xargs -I '{}' find '{}' -xdev -type d \\( -perm -0002 -a ! -perm -1000 \\) 2>/dev/null"
+    exec: "df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -type d \\( -perm -0002 -a ! -perm -1000 \\) 2>/dev/null"
     exit-status:
       or:
       - 0

--- a/section_7/cis_7.1/cis_7.1.12.yml
+++ b/section_7/cis_7.1/cis_7.1.12.yml
@@ -6,7 +6,7 @@
 command:
   unowned_ungrouped_dirs:
     title: 7.1.12 | Ensure no files or directories without an owner and a group exist
-    exec: df --local -P | awk {'if (NR!=1) print $7'} | xargs -I '{}' find '{}' -xdev {{ .Vars.rhel9cis_exclude_unowned_search_path }}
+    exec: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev {{ .Vars.rhel9cis_exclude_unowned_search_path }}
     exit-status: 0
     timeout: {{ .Vars.timeout_ms }}
     stdout:

--- a/section_7/cis_7.1/cis_7.1.12.yml
+++ b/section_7/cis_7.1/cis_7.1.12.yml
@@ -6,7 +6,7 @@
 command:
   unowned_ungrouped_dirs:
     title: 7.1.12 | Ensure no files or directories without an owner and a group exist
-    exec: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev {{ .Vars.rhel9cis_exclude_unowned_search_path }}
+    exec: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nouser {{ .Vars.rhel9cis_exclude_unowned_search_path }}
     exit-status: 0
     timeout: {{ .Vars.timeout_ms }}
     stdout:

--- a/section_7/cis_7.1/cis_7.1.13.yml
+++ b/section_7/cis_7.1/cis_7.1.13.yml
@@ -6,7 +6,7 @@
 command:
   audit_sgid_suid:
     title: 7.1.13 | Ensure SUID and SGID files are reviewed
-    exec: df --local -P | awk '{if (NR!=1) print $7}' | xargs -I '{}' find '{}' -xdev -type f \( -perm -2000 -o -perm -4000 \)
+    exec: df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -type f \( -perm -2000 -o -perm -4000 \)
     timeout: {{ .Vars.timeout_ms }}
     exit-status: 0
     stdout:

--- a/vars/CIS.yml
+++ b/vars/CIS.yml
@@ -571,4 +571,4 @@ rhel9cis_remote_log_retrycount: 100
 rhel9cis_remote_log_queuesize: 1000
 
 # Control 7.1.12
-rhel9cis_exclude_unowned_search_path: \(! -path "/run/user/*" -a ! -path "/proc/*" -a ! -path "*/containerd/*" -a ! -path "*/kubelet/pods/*" -a ! -path "*/kubelet/plugins/*" -a ! -path "/sys/fs/cgroup/memory/*" -a ! -path "/var/*/private/*" \)
+rhel9cis_exclude_unowned_search_path: \( ! -path "/run/user/*" -a ! -path "/proc/*" -a ! -path "*/containerd/*" -a ! -path "*/kubelet/pods/*" -a ! -path "*/kubelet/plugins/*" -a ! -path "/sys/fs/cgroup/memory/*" -a ! -path "/var/*/private/*" \)


### PR DESCRIPTION
The awk field selection in cis_7.1.1[123].yml is incorrect. The command df --local -P only returns 6 fields, so referencing field $7 yields an empty string.
Since these benchmarks were numbered cis_6.1.1[123] in the RHEL 8 benchmark, a global find-and-replace of "6" → "7" likely introduced this bug.